### PR TITLE
Fix user password hashing methods

### DIFF
--- a/user-service/app/models.py
+++ b/user-service/app/models.py
@@ -13,8 +13,10 @@ class User(Base):
     email = Column(String, unique=True, index=True)
     password = Column(String)
 
-    # def set_password(self, plain_password: str):
-    #     self.password = pwd_context.hash(plain_password)
+    def set_password(self, plain_password: str) -> None:
+        """Hash and store the provided password."""
+        self.password = pwd_context.hash(plain_password)
 
-    # def verify_password(self, plain_password: str):
-    #     return pwd_context.verify(plain_password, self.password)
+    def verify_password(self, plain_password: str) -> bool:
+        """Verify a plain password against the stored hash."""
+        return pwd_context.verify(plain_password, self.password)


### PR DESCRIPTION
## Summary
- implement `set_password` and `verify_password` methods in the user service model

## Testing
- `npm test -- --watchAll=false` *(fails: Unable to find element)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6848aed28a2c832db7debaddf433f928