### PR TITLE
Separate build/deploy workflows and add tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Authenticate to Artifact Registry
+        uses: docker/login-action@v2
+        with:
+          registry: europe-central2-docker.pkg.dev
+          username: _json_key
+          password: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+
+      - name: Build and push images
+        run: |
+          chmod +x build_and_push.sh
+          ./build_and_push.sh frontend
+          ./build_and_push.sh user-service
+          ./build_and_push.sh task-service
+          ./build_and_push.sh notification-service

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,40 +1,15 @@
-name: Build and Deploy
+name: Deploy
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Authenticate to Artifact Registry
-        uses: docker/login-action@v2
-        with:
-          registry: europe-central2-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
-
-      - name: Build and push images
-        run: |
-          chmod +x build_and_push.sh
-          ./build_and_push.sh frontend
-          ./build_and_push.sh user-service
-          ./build_and_push.sh task-service
-          ./build_and_push.sh notification-service
-
   deploy:
-    needs: build
     runs-on: ubuntu-latest
     environment:
       name: production
+    env:
+      USE_GKE_GCLOUD_AUTH_PLUGIN: 'True'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -44,6 +19,8 @@ jobs:
           mkdir -p $HOME/.kube
           echo "${{ secrets.KUBECONFIG_FILE }}" | base64 -d > $HOME/.kube/config
           chmod 600 $HOME/.kube/config
+          sed -i 's#/opt/homebrew/share/google-cloud-sdk/bin/gke-gcloud-auth-plugin#gke-gcloud-auth-plugin#' $HOME/.kube/config
+
       - name: Install gke-gcloud-auth-plugin
         run: |
           sudo apt-get install -y apt-transport-https ca-certificates gnupg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Test and QA
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          pip install flake8
+          pip install -r user-service/requirements.txt
+          pip install -r task-service/requirements.txt
+          pip install -r notification-service/requirements.txt
+      - name: Lint
+        run: flake8 user-service task-service notification-service
+      - name: Run backend tests
+        run: |
+          pytest user-service/app/tests
+          pytest task-service/app/tests
+          pytest notification-service/app/tests
+
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install frontend dependencies
+        run: npm ci --prefix frontend
+      - name: Run frontend tests
+        run: npm test --prefix frontend -- --watchAll=false


### PR DESCRIPTION
## Summary
- split CI workflow into `build.yml` and manual `deploy.yml`
- add `test.yml` for running backend & frontend tests plus flake8
- fix deployment workflow auth plugin path

## Testing
- `PYTHONPATH=user-service/app pytest user-service/app/tests`
- `PYTHONPATH=task-service/app pytest task-service/app/tests`
- `PYTHONPATH=notification-service/app pytest notification-service/app/tests`
- `npm test --prefix frontend -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68492f0f7ec4832d9650bd287f133e72