### PR TITLE
Fix GKE deployment auth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y google-cloud-cli-gke-gcloud-auth-plugin
 
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+
       - name: Deploy to GKE
         run: |
           kubectl apply -f gcp-iac/k8s_manifests/


### PR DESCRIPTION
## Summary
- add a Google Cloud authentication step to the deploy workflow

## Testing
- `pip install -r user-service/requirements.txt -r task-service/requirements.txt -r notification-service/requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'main')*

------
https://chatgpt.com/codex/tasks/task_e_684932473b40832db30edec263c11522