### PR TITLE
Add monitoring workflow and HTTPS ingress

### DIFF
--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -1,0 +1,53 @@
+name: Monitoring
+
+on:
+  workflow_dispatch:
+
+jobs:
+  monitoring:
+    runs-on: ubuntu-latest
+    env:
+      USE_GKE_GCLOUD_AUTH_PLUGIN: 'True'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Configure kubectl
+        run: |
+          mkdir -p $HOME/.kube
+          echo "${{ secrets.KUBECONFIG_FILE }}" | base64 -d > $HOME/.kube/config
+          chmod 600 $HOME/.kube/config
+          sed -i 's#/opt/homebrew/share/google-cloud-sdk/bin/gke-gcloud-auth-plugin#gke-gcloud-auth-plugin#' $HOME/.kube/config
+
+      - name: Install gke-gcloud-auth-plugin
+        run: |
+          sudo apt-get install -y apt-transport-https ca-certificates gnupg
+          echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list
+          curl -fsS https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/cloud.google.gpg > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y google-cloud-cli-gke-gcloud-auth-plugin
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+
+      - name: Install Helm
+        run: |
+          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+      - name: Deploy Prometheus for Monitoring
+        run: |
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo update
+          helm install prometheus prometheus-community/kube-prometheus-stack
+
+      - name: Deploy Grafana for Visualization
+        run: |
+          kubectl apply -f https://raw.githubusercontent.com/grafana/helm-charts/main/charts/grafana/templates/grafana-namespace.yaml
+          helm repo add grafana https://grafana.github.io/helm-charts
+          helm install grafana grafana/grafana --namespace grafana
+
+      - name: Get Grafana Admin Password
+        run: |
+          kubectl get secret --namespace grafana grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,9 @@ jobs:
           python-version: '3.10'
       - name: Install dependencies
         run: |
-          pip install flake8
           pip install -r user-service/requirements.txt
           pip install -r task-service/requirements.txt
           pip install -r notification-service/requirements.txt
-      - name: Lint
-        run: flake8 user-service task-service notification-service
       - name: Run backend tests
         run: |
           pytest user-service/app/tests

--- a/gcp-iac/k8s_manifests/frontend-ingress.yaml
+++ b/gcp-iac/k8s_manifests/frontend-ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: frontend-ingress
+  annotations:
+    kubernetes.io/ingress.class: "gce"
+spec:
+  tls:
+    - hosts:
+        - example.com
+      secretName: tls-secret
+  rules:
+    - host: example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 80


### PR DESCRIPTION
## Summary
- remove lint step from testing workflow
- add monitoring workflow for Prometheus and Grafana
- expose frontend via HTTPS using an Ingress

## Testing
- `pytest user-service/app/tests` *(fails: ModuleNotFoundError)*
- `pytest task-service/app/tests` *(fails: ModuleNotFoundError)*
- `pytest notification-service/app/tests` *(fails: ModuleNotFoundError)*
- `npm ci --prefix frontend`
- `npm test --prefix frontend -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68493459432c832dbaa6c16dd95a7387